### PR TITLE
SCL Windows Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository houses the definitions for jobs on our Jenkins instance. They ar
 | pipeline-safe_cli                             | Release pipeline for [safe-cli](https://github.com/maidsafe/safe-nd). This pipeline will build and test on Linux, Windows and macOS and deploy artifacts to GitHub releases. |
 | pipeline-safe-nd                              | Release pipeline for [safe-nd](https://github.com/maidsafe/safe-nd). Currently this release process only has a simple build and test stage. |
 | pipeline-safe_client_libs                     | Release pipeline for [safe_client_libs](https://github.com/maidsafe/safe_client_libs). Has a build, test and deploy stage, with artifacts for all platforms being deployed to an S3 bucket. |
+| rust_cache_build-safe_client_libs-windows     | Builds an SCL branch on a Windows node then uploads the resulting target directory as a tar. It's intended to be used as a cache for Windows builds. |
 
 ## Contributing
 
@@ -31,6 +32,7 @@ Please also add an entry to the jobs summary table to briefly describe the job.
   - Use `deploy` for jobs that do some kind of deployment (e.g. updating the Jenkins environment)
   - Use `docker_build` for building and pushing containers
   - Use `pipeline` for product release pipelines
+  - Use `rust_cache_build` for generating 'caches' for Windows or macOS
   - Use `util` for miscellaneous stuff that won't quite fit anywhere else
 
 ## License

--- a/job_dsl_seed.groovy
+++ b/job_dsl_seed.groovy
@@ -150,7 +150,7 @@ pipelineJob('rust_cache_build-safe_client_libs-windows') {
                 git {
                     remote { url('https://github.com/maidsafe/jenkins-jobs.git') }
                     branches('master')
-                    scriptPath('rust_cache_build-safe_client_libs-windows')
+                    scriptPath('rust_cache_build-safe_client_libs-windows/Jenkinsfile')
                     extensions { }
                 }
             }

--- a/job_dsl_seed.groovy
+++ b/job_dsl_seed.groovy
@@ -19,7 +19,7 @@ multibranchPipelineJob('pipeline-safe_client_libs') {
     }
 }
 
-multibranchPipelineJob('pipeline-safe-nd') {
+multibranchPipelineJob('pipeline-safe_nd') {
     branchSources {
         github {
             checkoutCredentialsId('github_maidsafe_token_credentials')
@@ -129,6 +129,31 @@ multibranchPipelineJob('pipeline-safe_cli') {
     factory {
         workflowBranchProjectFactory {
             scriptPath('Jenkinsfile')
+        }
+    }
+}
+
+pipelineJob('rust_cache_build-safe_client_libs-windows') {
+    parameters {
+        stringParam('BRANCH', 'experimental')
+        stringParam(
+            'REPO_URL',
+            'https://github.com/maidsafe/safe_client_libs.git')
+        stringParam('S3_BUCKET', 'safe-jenkins-build-artifacts')
+    }
+
+    description('Builds Safe Client Libs on Windows then uploads the target directory for use as a cache.')
+
+    definition {
+        cpsScm {
+            scm {
+                git {
+                    remote { url('https://github.com/maidsafe/jenkins-jobs.git') }
+                    branches('master')
+                    scriptPath('rust_cache_build-safe_client_libs-windows')
+                    extensions { }
+                }
+            }
         }
     }
 }

--- a/rust_cache_build-safe_client_libs-windows/Jenkinsfile
+++ b/rust_cache_build-safe_client_libs-windows/Jenkinsfile
@@ -1,0 +1,17 @@
+stage('build & upload') {
+    node('windows') {
+        sh('rm -rf **')
+        git([url: env.REPO_URL, branch: env.BRANCH])
+        sh('make build-mock')
+        sh('tar -C target -zcvf scl-experimental-windows-cache.tar.gz .')
+        withAWS(credentials: 'aws_jenkins_build_artifacts_user', region: 'eu-west-2') {
+            s3Delete(
+                bucket: "${env.S3_BUCKET}",
+                path: 'scl-experimental-windows-cache.tar.gz')
+            s3Upload(
+                bucket: "${env.S3_BUCKET}",
+                file: 'scl-experimental-windows-cache.tar.gz',
+                acl: 'PublicRead')
+        }
+    }
+}


### PR DESCRIPTION
This introduces a simple little job that builds SCL on Windows and then uploads the target directory as a cache.

The pipeline for SCL pulls this cache in.