### PR TITLE
Pass Image Tag Parameters

### DIFF
--- a/ami_build-safe_cli_slave/Jenkinsfile
+++ b/ami_build-safe_cli_slave/Jenkinsfile
@@ -6,6 +6,7 @@ stage('build') {
             accessKeyVariable: "AWS_ACCESS_KEY_ID",
             secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_cli']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")

--- a/ami_build-safe_client_libs_slave/Jenkinsfile
+++ b/ami_build-safe_client_libs_slave/Jenkinsfile
@@ -6,6 +6,7 @@ stage('build') {
             accessKeyVariable: "AWS_ACCESS_KEY_ID",
             secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_client_libs']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")

--- a/ami_build-safe_nd_slave/Jenkinsfile
+++ b/ami_build-safe_nd_slave/Jenkinsfile
@@ -6,6 +6,7 @@ stage('build') {
             accessKeyVariable: "AWS_ACCESS_KEY_ID",
             secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_nd']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")


### PR DESCRIPTION
Since the build containers will no longer be versioned along with the application, we can just supply a default value for this parameter.

Versioning the build container along with the application doesn't work, because if you have a version change commit to go to a new version, it will try and run the build, but there will be no container with the new version yet, so it'll fail. We don't really need to version the build environment along with the app. If we ever need a container to be versioned to build at a particular point in time, we can just rebuild the container from a tag.