### PR TITLE
Use Dockerfile Repo Commit Hash for AMIs

### DIFF
--- a/ami_build-rust_slave_windows/Jenkinsfile
+++ b/ami_build-rust_slave_windows/Jenkinsfile
@@ -1,5 +1,5 @@
-stage('build') {
-    node('util') {
+stage("build") {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
         withCredentials(
             [[$class:

--- a/ami_build-safe_cli_slave/Jenkinsfile
+++ b/ami_build-safe_cli_slave/Jenkinsfile
@@ -1,5 +1,5 @@
-stage('build') {
-    node('util') {
+stage("build") {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
         withCredentials(
             [[$class:
@@ -7,10 +7,10 @@ stage('build') {
                 credentialsId: "packer",
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
-            withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+            withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
                      "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
-                     'SAFE_IMAGE_TAG=build',
-                     'SAFE_PROJECT=safe_cli']) {
+                     "SAFE_IMAGE_TAG=build",
+                     "SAFE_PROJECT=safe_cli"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")
             }

--- a/ami_build-safe_cli_slave/Jenkinsfile
+++ b/ami_build-safe_cli_slave/Jenkinsfile
@@ -8,6 +8,7 @@ stage('build') {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
                      'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_cli']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_client_libs_slave/Jenkinsfile
+++ b/ami_build-safe_client_libs_slave/Jenkinsfile
@@ -1,5 +1,5 @@
-stage('build') {
-    node('util') {
+stage("build") {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
         withCredentials(
             [[$class:
@@ -7,10 +7,10 @@ stage('build') {
                 credentialsId: "packer",
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
-            withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+            withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
                      "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
-                     'SAFE_IMAGE_TAG=build',
-                     'SAFE_PROJECT=safe_client_libs']) {
+                     "SAFE_IMAGE_TAG=build",
+                     "SAFE_PROJECT=safe_client_libs"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")
             }

--- a/ami_build-safe_client_libs_slave/Jenkinsfile
+++ b/ami_build-safe_client_libs_slave/Jenkinsfile
@@ -8,6 +8,7 @@ stage('build') {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
                      'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_client_libs']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_nd_slave/Jenkinsfile
+++ b/ami_build-safe_nd_slave/Jenkinsfile
@@ -1,5 +1,5 @@
-stage('build') {
-    node('util') {
+stage("build") {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
         withCredentials(
             [[$class:
@@ -7,10 +7,10 @@ stage('build') {
                 credentialsId: "packer",
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
-            withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+            withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
                      "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
-                     'SAFE_IMAGE_TAG=build',
-                     'SAFE_PROJECT=safe_nd']) {
+                     "SAFE_IMAGE_TAG=build",
+                     "SAFE_PROJECT=safe_nd"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")
             }

--- a/ami_build-safe_nd_slave/Jenkinsfile
+++ b/ami_build-safe_nd_slave/Jenkinsfile
@@ -8,6 +8,7 @@ stage('build') {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
                      'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_nd']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_vault_slave/Jenkinsfile
+++ b/ami_build-safe_vault_slave/Jenkinsfile
@@ -1,5 +1,5 @@
-stage('build') {
-    node('util') {
+stage("build") {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
         withCredentials(
             [[$class:
@@ -7,10 +7,10 @@ stage('build') {
                 credentialsId: "packer",
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
-            withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+            withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
                      "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
-                     'SAFE_IMAGE_TAG=build',
-                     'SAFE_PROJECT=safe_vault']) {
+                     "SAFE_IMAGE_TAG=build",
+                     "SAFE_PROJECT=safe_vault"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")
                 sh("make box-docker_slave-centos-7.6-x86_64-aws")
             }

--- a/ami_build-safe_vault_slave/Jenkinsfile
+++ b/ami_build-safe_vault_slave/Jenkinsfile
@@ -8,6 +8,7 @@ stage('build') {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(['SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass',
+                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
                      'SAFE_IMAGE_TAG=build',
                      'SAFE_PROJECT=safe_vault']) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/docker_build-safe_cli_build_container/Jenkinsfile
+++ b/docker_build-safe_cli_build_container/Jenkinsfile
@@ -1,20 +1,20 @@
-stage('build & push') {
+stage("build & push") {
     commit_hash = ""
-    node('util') {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
-        sh('make build-container')
-        sh('make push-container')
+        sh("make build-container")
+        sh("make push-container")
         commitHash = sh(
             returnStdout: true,
             script: "git rev-parse --short HEAD").trim()
     }
     build(
-        job: 'ami_build-safe_cli_slave',
+        job: "ami_build-safe_cli_slave",
         parameters:
         [
             [
-                $class: 'StringParameterValue',
-                name: 'SAFE_COMMIT_HASH',
+                $class: "StringParameterValue",
+                name: "SAFE_COMMIT_HASH",
                 value: commitHash
             ]
         ],

--- a/docker_build-safe_cli_build_container/Jenkinsfile
+++ b/docker_build-safe_cli_build_container/Jenkinsfile
@@ -1,8 +1,22 @@
 stage('build & push') {
+    commit_hash = ""
     node('util') {
         git([url: env.REPO_URL, branch: env.BRANCH])
         sh('make build-container')
         sh('make push-container')
+        commitHash = sh(
+            returnStdout: true,
+            script: "git rev-parse --short HEAD").trim()
     }
-    build(job: 'ami_build-safe_cli_slave', wait: false)
+    build(
+        job: 'ami_build-safe_cli_slave',
+        parameters:
+        [
+            [
+                $class: 'StringParameterValue',
+                name: 'SAFE_COMMIT_HASH',
+                value: commitHash
+            ]
+        ],
+        wait: false)
 }

--- a/docker_build-safe_client_libs_build_container/Jenkinsfile
+++ b/docker_build-safe_client_libs_build_container/Jenkinsfile
@@ -1,8 +1,22 @@
 stage('build & push') {
+    commit_hash = ""
     node('util') {
         git([url: env.REPO_URL, branch: env.BRANCH])
         sh('make build-container')
         sh('make push-container')
+        commitHash = sh(
+            returnStdout: true,
+            script: "git rev-parse --short HEAD").trim()
     }
-    build(job: 'ami_build-safe_client_libs_slave', wait: false)
+    build(
+        job: 'ami_build-safe_client_libs_slave',
+        parameters:
+        [
+            [
+                $class: 'StringParameterValue',
+                name: 'SAFE_COMMIT_HASH',
+                value: commitHash
+            ]
+        ],
+        wait: false)
 }

--- a/docker_build-safe_client_libs_build_container/Jenkinsfile
+++ b/docker_build-safe_client_libs_build_container/Jenkinsfile
@@ -1,20 +1,20 @@
-stage('build & push') {
+stage("build & push") {
     commit_hash = ""
-    node('util') {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
-        sh('make build-container')
-        sh('make push-container')
+        sh("make build-container")
+        sh("make push-container")
         commitHash = sh(
             returnStdout: true,
             script: "git rev-parse --short HEAD").trim()
     }
     build(
-        job: 'ami_build-safe_client_libs_slave',
+        job: "ami_build-safe_client_libs_slave",
         parameters:
         [
             [
-                $class: 'StringParameterValue',
-                name: 'SAFE_COMMIT_HASH',
+                $class: "StringParameterValue",
+                name: "SAFE_COMMIT_HASH",
                 value: commitHash
             ]
         ],

--- a/docker_build-safe_nd_build_container/Jenkinsfile
+++ b/docker_build-safe_nd_build_container/Jenkinsfile
@@ -1,8 +1,22 @@
 stage('build & push') {
+    commit_hash = ""
     node('util') {
         git([url: env.REPO_URL, branch: env.BRANCH])
         sh('make build-container')
         sh('make push-container')
+        commitHash = sh(
+            returnStdout: true,
+            script: "git rev-parse --short HEAD").trim()
     }
-    build(job: 'ami_build-safe_nd_slave', wait: false)
+    build(
+        job: 'ami_build-safe_nd_slave',
+        parameters:
+        [
+            [
+                $class: 'StringParameterValue',
+                name: 'SAFE_COMMIT_HASH',
+                value: commitHash
+            ]
+        ],
+        wait: false)
 }

--- a/docker_build-safe_nd_build_container/Jenkinsfile
+++ b/docker_build-safe_nd_build_container/Jenkinsfile
@@ -1,20 +1,20 @@
-stage('build & push') {
+stage("build & push") {
     commit_hash = ""
-    node('util') {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
-        sh('make build-container')
-        sh('make push-container')
+        sh("make build-container")
+        sh("make push-container")
         commitHash = sh(
             returnStdout: true,
             script: "git rev-parse --short HEAD").trim()
     }
     build(
-        job: 'ami_build-safe_nd_slave',
+        job: "ami_build-safe_nd_slave",
         parameters:
         [
             [
-                $class: 'StringParameterValue',
-                name: 'SAFE_COMMIT_HASH',
+                $class: "StringParameterValue",
+                name: "SAFE_COMMIT_HASH",
                 value: commitHash
             ]
         ],

--- a/docker_build-safe_vault_build_container/Jenkinsfile
+++ b/docker_build-safe_vault_build_container/Jenkinsfile
@@ -1,20 +1,20 @@
-stage('build & push') {
+stage("build & push") {
     commit_hash = ""
-    node('util') {
+    node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
-        sh('make build-container')
-        sh('make push-container')
+        sh("make build-container")
+        sh("make push-container")
         commitHash = sh(
             returnStdout: true,
             script: "git rev-parse --short HEAD").trim()
     }
     build(
-        job: 'ami_build-safe_vault_slave',
+        job: "ami_build-safe_vault_slave",
         parameters:
         [
             [
-                $class: 'StringParameterValue',
-                name: 'SAFE_COMMIT_HASH',
+                $class: "StringParameterValue",
+                name: "SAFE_COMMIT_HASH",
                 value: commitHash
             ]
         ],

--- a/docker_build-safe_vault_build_container/Jenkinsfile
+++ b/docker_build-safe_vault_build_container/Jenkinsfile
@@ -1,8 +1,22 @@
 stage('build & push') {
+    commit_hash = ""
     node('util') {
         git([url: env.REPO_URL, branch: env.BRANCH])
         sh('make build-container')
         sh('make push-container')
+        commitHash = sh(
+            returnStdout: true,
+            script: "git rev-parse --short HEAD").trim()
     }
-    build(job: 'ami_build-safe_vault_slave', wait: false)
+    build(
+        job: 'ami_build-safe_vault_slave',
+        parameters:
+        [
+            [
+                $class: 'StringParameterValue',
+                name: 'SAFE_COMMIT_HASH',
+                value: commitHash
+            ]
+        ],
+        wait: false)
 }

--- a/rust_cache_build-safe_client_libs-windows/Jenkinsfile
+++ b/rust_cache_build-safe_client_libs-windows/Jenkinsfile
@@ -1,17 +1,17 @@
-stage('build & upload') {
-    node('windows') {
-        sh('rm -rf **')
+stage("build & upload") {
+    node("windows") {
+        sh("rm -rf **")
         git([url: env.REPO_URL, branch: env.BRANCH])
-        sh('make build-mock')
-        sh('tar -C target -zcvf scl-experimental-windows-cache.tar.gz .')
-        withAWS(credentials: 'aws_jenkins_build_artifacts_user', region: 'eu-west-2') {
+        sh("make build-mock")
+        sh("tar -C target -zcvf scl-experimental-windows-cache.tar.gz .")
+        withAWS(credentials: "aws_jenkins_build_artifacts_user", region: "eu-west-2") {
             s3Delete(
                 bucket: "${env.S3_BUCKET}",
-                path: 'scl-experimental-windows-cache.tar.gz')
+                path: "scl-experimental-windows-cache.tar.gz")
             s3Upload(
                 bucket: "${env.S3_BUCKET}",
-                file: 'scl-experimental-windows-cache.tar.gz',
-                acl: 'PublicRead')
+                file: "scl-experimental-windows-cache.tar.gz",
+                acl: "PublicRead")
         }
     }
 }

--- a/rust_cache_build-safe_vault-windows/Jenkinsfile
+++ b/rust_cache_build-safe_vault-windows/Jenkinsfile
@@ -1,17 +1,17 @@
-stage('build & upload') {
-    node('windows') {
-        sh('rm -rf **')
+stage("build & upload") {
+    node("windows") {
+        sh("rm -rf **")
         git([url: env.REPO_URL, branch: env.BRANCH])
-        sh('make test')
+        sh("make test")
         sh("tar -C target -zcvf safe_vault-${env.BRANCH}-windows-cache.tar.gz .")
-        withAWS(credentials: 'aws_jenkins_build_artifacts_user', region: 'eu-west-2') {
+        withAWS(credentials: "aws_jenkins_build_artifacts_user", region: "eu-west-2") {
             s3Delete(
                 bucket: "${env.S3_BUCKET}",
                 path: "safe_vault-${env.BRANCH}-windows-cache.tar.gz")
             s3Upload(
                 bucket: "${env.S3_BUCKET}",
                 file: "safe_vault-${env.BRANCH}-windows-cache.tar.gz",
-                acl: 'PublicRead')
+                acl: "PublicRead")
         }
     }
 }


### PR DESCRIPTION
Hi Stephen,

As discussed, we need to use the commit hash of the repo where the Dockerfile resides, as opposed to the commit hash of the safe-build-infrastructure repo, which doesn't necessarily change in sync with the Dockerfiles.

Cheers,

Chris