### PR TITLE
fix/job: reference correct ami build

### DIFF
--- a/docker_build-safe_auth_cli_build_container/Jenkinsfile
+++ b/docker_build-safe_auth_cli_build_container/Jenkinsfile
@@ -9,7 +9,7 @@ stage("build & push") {
             script: "git rev-parse --short HEAD").trim()
     }
     build(
-        job: "ami_build-safe_authenticator_cli_slave",
+        job: "ami_build-safe_auth_cli_slave",
         parameters:
         [
             [


### PR DESCRIPTION
Sorry, I started off referencing this project as 'safe_authenticator_cli', but then decided that was too long and shortened it to auth, but I forgot to update this job.