### PR TITLE
feat/job: 2 containers for safe-cli

### DIFF
--- a/docker_build-safe_cli_build_container/Jenkinsfile
+++ b/docker_build-safe_cli_build_container/Jenkinsfile
@@ -1,12 +1,21 @@
 stage("build & push") {
     commit_hash = ""
-    node("util") {
-        git([url: env.REPO_URL, branch: env.BRANCH])
-        sh("make build-container")
-        sh("make push-container")
-        commitHash = sh(
-            returnStdout: true,
-            script: "git rev-parse --short HEAD").trim()
+    parallel dev_container: {
+        node("util") {
+            git([url: env.REPO_URL, branch: env.BRANCH])
+            sh("make build-container")
+            sh("make push-container")
+            commitHash = sh(
+                returnStdout: true,
+                script: "git rev-parse --short HEAD").trim()
+        }
+    },
+    non_dev_container: {
+        node("util") {
+            git([url: env.REPO_URL, branch: env.BRANCH])
+            sh("make build-dev-container")
+            sh("make push-dev-container")
+        }
     }
     build(
         job: "ami_build-safe_cli_slave",


### PR DESCRIPTION
On account of distributing a dev and a non-dev build for safe-cli, we need a container for each of these.