### PR TITLE
refactor/job: use build number in ami name

### DIFF
--- a/ami_build-safe_auth_cli_slave/Jenkinsfile
+++ b/ami_build-safe_auth_cli_slave/Jenkinsfile
@@ -1,6 +1,7 @@
 stage("build") {
     node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
+        buildNumber = "${env.BUILD_NUMBER}".padLeft(4, '0')
         withCredentials(
             [[$class:
                 "AmazonWebServicesCredentialsBinding",
@@ -8,7 +9,7 @@ stage("build") {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
-                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
+                     "SAFE_COMMIT_HASH=${buildNumber}",
                      "SAFE_IMAGE_TAG=build",
                      "SAFE_PROJECT=safe_authenticator_cli"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_cli_slave/Jenkinsfile
+++ b/ami_build-safe_cli_slave/Jenkinsfile
@@ -1,6 +1,7 @@
 stage("build") {
     node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
+        buildNumber = "${env.BUILD_NUMBER}".padLeft(4, '0')
         withCredentials(
             [[$class:
                 "AmazonWebServicesCredentialsBinding",
@@ -8,7 +9,7 @@ stage("build") {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
-                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
+                     "SAFE_COMMIT_HASH=${buildNumber}",
                      "SAFE_IMAGE_TAG=build",
                      "SAFE_PROJECT=safe_cli"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_client_libs_slave/Jenkinsfile
+++ b/ami_build-safe_client_libs_slave/Jenkinsfile
@@ -1,6 +1,7 @@
 stage("build") {
     node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
+        buildNumber = "${env.BUILD_NUMBER}".padLeft(4, '0')
         withCredentials(
             [[$class:
                 "AmazonWebServicesCredentialsBinding",
@@ -8,7 +9,7 @@ stage("build") {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
-                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
+                     "SAFE_COMMIT_HASH=${buildNumber}",
                      "SAFE_IMAGE_TAG=build",
                      "SAFE_PROJECT=safe_client_libs"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_nd_slave/Jenkinsfile
+++ b/ami_build-safe_nd_slave/Jenkinsfile
@@ -1,6 +1,7 @@
 stage("build") {
     node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
+        buildNumber = "${env.BUILD_NUMBER}".padLeft(4, '0')
         withCredentials(
             [[$class:
                 "AmazonWebServicesCredentialsBinding",
@@ -8,7 +9,7 @@ stage("build") {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
-                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
+                     "SAFE_COMMIT_HASH=${buildNumber}",
                      "SAFE_IMAGE_TAG=build",
                      "SAFE_PROJECT=safe_nd"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")

--- a/ami_build-safe_vault_slave/Jenkinsfile
+++ b/ami_build-safe_vault_slave/Jenkinsfile
@@ -1,6 +1,7 @@
 stage("build") {
     node("util") {
         git([url: env.REPO_URL, branch: env.BRANCH])
+        buildNumber = "${env.BUILD_NUMBER}".padLeft(4, '0')
         withCredentials(
             [[$class:
                 "AmazonWebServicesCredentialsBinding",
@@ -8,7 +9,7 @@ stage("build") {
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
             withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
-                     "SAFE_COMMIT_HASH=${params.SAFE_COMMIT_HASH}",
+                     "SAFE_COMMIT_HASH=${buildNumber}",
                      "SAFE_IMAGE_TAG=build",
                      "SAFE_PROJECT=safe_vault"]) {
                 echo("Building Docker slave for ${env.SAFE_PROJECT} with ${env.SAFE_IMAGE_TAG} tag")


### PR DESCRIPTION
Use the build number as opposed to the commit hash, because the commit
hash isn't always changing when this build is run. We could do it a
different way and check that there is already an AMI with that commit
hash and do nothing, but we actually want a build to run sometimes even
if that's the case: for example if there's been a Rust upgrade, we need
the process to run again to pull in the new 'latest' tag.

The SAFE_COMMIT_HASH variable should really be renamed. I'll do that as
a separate PR on the safe-build-infrastructure repo.