### PR TITLE
fix/job: larger timeout for ami build

### DIFF
--- a/docker_build-safe_cli_build_container/Jenkinsfile
+++ b/docker_build-safe_cli_build_container/Jenkinsfile
@@ -63,7 +63,9 @@ stage("build & push") {
 
 def buildAndPushContainer(component, type, target) {
     git([url: env.REPO_URL, branch: env.BRANCH])
-    withEnv(["SAFE_CLI_CONTAINER_COMPONENT=${component}",
+    withEnv(["AWS_MAX_ATTEMPTS=80",
+             "AWS_POLL_DELAY_SECONDS=60",
+             "SAFE_CLI_CONTAINER_COMPONENT=${component}",
              "SAFE_CLI_CONTAINER_TYPE=${type}",
              "SAFE_CLI_CONTAINER_TARGET=${target}"]) {
         sh("make build-container")


### PR DESCRIPTION
The slaves can have quite a lot of containers on them now and by default Packer isn't providing enough time for the AMI to be successfully copied and saved.

Suggestion taken from here:
https://github.com/hashicorp/packer/issues/6536