### PR TITLE
fix/job: larger timeout for ami build

### DIFF
--- a/ami_build-safe_cli_slave/Jenkinsfile
+++ b/ami_build-safe_cli_slave/Jenkinsfile
@@ -8,7 +8,9 @@ stage("build") {
                 credentialsId: "packer",
                 accessKeyVariable: "AWS_ACCESS_KEY_ID",
                 secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
-            withEnv(["SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
+            withEnv(["AWS_MAX_ATTEMPTS=100",
+                     "AWS_POLL_DELAY_SECONDS=60",
+                     "SAFE_BUILD_INFRA_VAULT_PASS_PATH=/home/util/.ansible/vault-pass",
                      "SAFE_COMMIT_HASH=${buildNumber}",
                      "SAFE_IMAGE_TAG=build",
                      "SAFE_PROJECT=safe_cli"]) {


### PR DESCRIPTION
The slaves can have quite a lot of containers on them now and by default Packer isn't providing enough time for the AMI to be successfully copied and saved.

Suggestion taken from here:
https://github.com/hashicorp/packer/issues/6536